### PR TITLE
[Board-55] Authentication에서 인증 주체 가져오기

### DIFF
--- a/src/main/java/com/example/diaryboard/controller/MemberController.java
+++ b/src/main/java/com/example/diaryboard/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.example.diaryboard.controller;
 
+import com.example.diaryboard.dto.BasicMessageResponse;
 import com.example.diaryboard.dto.member.*;
 import com.example.diaryboard.service.MemberService;
 import jakarta.validation.Valid;
@@ -32,35 +33,30 @@ public class MemberController {
     }
 
     @GetMapping("/reissue")
-    public ResponseEntity<ReissueResponse> reissue(@RequestHeader("authorization") String refreshToken) {
-        refreshToken = refreshToken.replace("Bearer ", "");
-        ReissueResponse response = memberService.reissue(refreshToken);
+    public ResponseEntity<ReissueResponse> reissue() {
+        ReissueResponse response = memberService.reissue();
 
         return ResponseEntity.ok().body(response);
     }
 
     @GetMapping
-    public ResponseEntity<MemberProfileResponse> getMemberProfile(@RequestHeader("authorization") String accessToken) {
-        accessToken = accessToken.replace("Bearer ", "");
-        MemberProfileResponse response = memberService.getMemberProfile(accessToken);
+    public ResponseEntity<MemberProfileResponse> getMemberProfile() {
+        MemberProfileResponse response = memberService.getMemberProfile();
 
         return ResponseEntity.ok().body(response);
     }
 
     @PatchMapping
-    public ResponseEntity<BasicMessageResponse> updateMemberProfile(@RequestHeader("authorization") String accessToken,
-                                                                    @RequestBody MemberProfileRequest request) {
-        accessToken = accessToken.replace("Bearer ", "");
-        memberService.updateMemberProfile(accessToken, request);
+    public ResponseEntity<BasicMessageResponse> updateMemberProfile(@RequestBody MemberProfileRequest request) {
+        memberService.updateMemberProfile(request);
         BasicMessageResponse response = new BasicMessageResponse("회원정보 수정 성공");
 
         return ResponseEntity.ok().body(response);
     }
 
     @DeleteMapping
-    public ResponseEntity<BasicMessageResponse> deleteMember(@RequestHeader("authorization") String accessToken) {
-        accessToken = accessToken.replace("Bearer ", "");
-        memberService.deleteMember(accessToken);
+    public ResponseEntity<BasicMessageResponse> deleteMember() {
+        memberService.deleteMember();
         BasicMessageResponse response = new BasicMessageResponse("회원탈퇴 성공");
 
         return ResponseEntity.ok().body(response);

--- a/src/main/java/com/example/diaryboard/dto/BasicMessageResponse.java
+++ b/src/main/java/com/example/diaryboard/dto/BasicMessageResponse.java
@@ -1,4 +1,4 @@
-package com.example.diaryboard.dto.member;
+package com.example.diaryboard.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/example/diaryboard/global/security/CustomJwtAuthenticationConverter.java
+++ b/src/main/java/com/example/diaryboard/global/security/CustomJwtAuthenticationConverter.java
@@ -14,9 +14,9 @@ import java.util.List;
 
 public class CustomJwtAuthenticationConverter implements Converter<Jwt, AbstractAuthenticationToken> {
 
-    private Converter<Jwt, Collection<GrantedAuthority>> jwtGrantedAuthoritiesConverter = new JwtGrantedAuthoritiesConverter();
+    private final Converter<Jwt, Collection<GrantedAuthority>> jwtGrantedAuthoritiesConverter = new JwtGrantedAuthoritiesConverter();
 
-    private String principalClaimName = JwtClaimNames.SUB;
+    private final String principalClaimName = JwtClaimNames.SUB;
 
     @Override
     public final AbstractAuthenticationToken convert(Jwt jwt) {

--- a/src/main/java/com/example/diaryboard/global/security/SecurityConfig.java
+++ b/src/main/java/com/example/diaryboard/global/security/SecurityConfig.java
@@ -15,8 +15,7 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-import java.util.Arrays;
-import java.util.Collections;
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -52,10 +51,9 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(Collections.singletonList("http://localhost:3000"));
-        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "DELETE", "PATCH"));
-        configuration.setAllowCredentials(true);
-        configuration.setAllowedHeaders(Arrays.asList("Authorization", "Cache-Control", "Content-Type"));
+        configuration.setAllowedOrigins(List.of("*"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "DELETE", "PATCH"));
+        configuration.setAllowedHeaders(List.of("*"));
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);


### PR DESCRIPTION
[BOARD-55](https://dev-cycle.atlassian.net/browse/BOARD-55)

- 기존에는 Header에서 Token 파싱해서 사용
- SecurityContextHolder에서 Authentication을 가져와서 인증 주체 확인하도록 수정

[BOARD-55]: https://dev-cycle.atlassian.net/browse/BOARD-55?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ