### PR TITLE
[Board-67] 댓글 생성-수정-삭제 API 구현

### DIFF
--- a/src/main/java/com/example/diaryboard/controller/CommentController.java
+++ b/src/main/java/com/example/diaryboard/controller/CommentController.java
@@ -1,0 +1,42 @@
+package com.example.diaryboard.controller;
+
+import com.example.diaryboard.dto.BasicMessageResponse;
+import com.example.diaryboard.dto.comment.CreateCommentRequest;
+import com.example.diaryboard.dto.comment.UpdateCommentRequest;
+import com.example.diaryboard.service.CommentService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/comments")
+@RequiredArgsConstructor
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @PostMapping
+    public ResponseEntity<BasicMessageResponse> createComment(@RequestBody @Valid CreateCommentRequest request) {
+        commentService.createComment(request);
+        BasicMessageResponse response = new BasicMessageResponse("댓글 생성 성공");
+
+        return ResponseEntity.ok().body(response);
+    }
+
+    @PatchMapping("/{commentId}")
+    public ResponseEntity<BasicMessageResponse> updateComment(@PathVariable Long commentId, @RequestBody @Valid UpdateCommentRequest request) {
+        commentService.updateComment(commentId, request);
+        BasicMessageResponse response = new BasicMessageResponse("댓글 수정 성공");
+
+        return ResponseEntity.ok().body(response);
+    }
+    
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<BasicMessageResponse> deleteComment(@PathVariable Long commentId) {
+        commentService.deleteComment(commentId);
+        BasicMessageResponse response = new BasicMessageResponse("댓글 삭제 성공");
+
+        return ResponseEntity.ok().body(response);
+    }
+}

--- a/src/main/java/com/example/diaryboard/dto/comment/CreateCommentRequest.java
+++ b/src/main/java/com/example/diaryboard/dto/comment/CreateCommentRequest.java
@@ -1,0 +1,27 @@
+package com.example.diaryboard.dto.comment;
+
+import com.example.diaryboard.entity.Comment;
+import com.example.diaryboard.entity.Member;
+import com.example.diaryboard.entity.Post;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class CreateCommentRequest {
+
+    @NotBlank
+    private String content;
+
+    public Comment toEntity(Member member, Post post) {
+        return Comment.builder()
+                .content(content)
+                .member(member)
+                .post(post)
+                .build();
+    }
+}

--- a/src/main/java/com/example/diaryboard/dto/comment/CreateCommentRequest.java
+++ b/src/main/java/com/example/diaryboard/dto/comment/CreateCommentRequest.java
@@ -3,7 +3,10 @@ package com.example.diaryboard.dto.comment;
 import com.example.diaryboard.entity.Comment;
 import com.example.diaryboard.entity.Member;
 import com.example.diaryboard.entity.Post;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -12,7 +15,11 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class CreateCommentRequest {
+
+    @NotNull
+    private Long postId;
 
     @NotBlank
     private String content;

--- a/src/main/java/com/example/diaryboard/dto/comment/UpdateCommentRequest.java
+++ b/src/main/java/com/example/diaryboard/dto/comment/UpdateCommentRequest.java
@@ -1,0 +1,16 @@
+package com.example.diaryboard.dto.comment;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class UpdateCommentRequest {
+
+    @NotBlank
+    private String content;
+}

--- a/src/main/java/com/example/diaryboard/dto/post/converter/StringToDirectionTypeConverter.java
+++ b/src/main/java/com/example/diaryboard/dto/post/converter/StringToDirectionTypeConverter.java
@@ -1,7 +1,6 @@
 package com.example.diaryboard.dto.post.converter;
 
 import com.example.diaryboard.dto.post.DirectionType;
-import com.example.diaryboard.dto.post.SortType;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/com/example/diaryboard/dto/post/converter/StringToSearchTypeConverter.java
+++ b/src/main/java/com/example/diaryboard/dto/post/converter/StringToSearchTypeConverter.java
@@ -1,7 +1,6 @@
 package com.example.diaryboard.dto.post.converter;
 
 import com.example.diaryboard.dto.post.SearchType;
-import com.example.diaryboard.dto.post.SortType;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/com/example/diaryboard/entity/Comment.java
+++ b/src/main/java/com/example/diaryboard/entity/Comment.java
@@ -21,4 +21,8 @@ public class Comment extends BaseTimeEntity {
     private Post post;
 
     private String content;
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
 }

--- a/src/main/java/com/example/diaryboard/global/exception/ExceptionCode.java
+++ b/src/main/java/com/example/diaryboard/global/exception/ExceptionCode.java
@@ -17,7 +17,9 @@ public enum ExceptionCode {
     INVALID_TOKEN(BAD_REQUEST, "TOKEN_001", "유효하지 않은 토큰입니다"),
     UNAUTHORIZED_TOKEN(UNAUTHORIZED, "TOKEN_002", "권한이 없는 토큰입니다"),
     INVALID_POST(BAD_REQUEST, "POST_001", "존재하지 않는 게시글입니다"),
-    UNAUTHORIZED_POST(UNAUTHORIZED, "POST_002", "잘못된 게시글 요청입니다");
+    UNAUTHORIZED_POST(UNAUTHORIZED, "POST_002", "잘못된 게시글 요청입니다"),
+    INVALID_COMMENT(BAD_REQUEST, "COMMENT_001", "존재하지 않는 댓글입니다"),
+    UNAUTHORIZED_COMMENT(UNAUTHORIZED, "COMMENT_002", "잘못된 댓글 요청입니다");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/example/diaryboard/repository/CommentRepository.java
+++ b/src/main/java/com/example/diaryboard/repository/CommentRepository.java
@@ -1,0 +1,7 @@
+package com.example.diaryboard.repository;
+
+import com.example.diaryboard.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/src/main/java/com/example/diaryboard/repository/CommentRepository.java
+++ b/src/main/java/com/example/diaryboard/repository/CommentRepository.java
@@ -1,7 +1,13 @@
 package com.example.diaryboard.repository;
 
 import com.example.diaryboard.entity.Comment;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    @EntityGraph(attributePaths = {"member"})
+    Optional<Comment> findById(Long id);
 }

--- a/src/main/java/com/example/diaryboard/service/CommentService.java
+++ b/src/main/java/com/example/diaryboard/service/CommentService.java
@@ -1,6 +1,8 @@
 package com.example.diaryboard.service;
 
 import com.example.diaryboard.dto.comment.CreateCommentRequest;
+import com.example.diaryboard.dto.comment.UpdateCommentRequest;
+import com.example.diaryboard.entity.Comment;
 import com.example.diaryboard.entity.Member;
 import com.example.diaryboard.entity.Post;
 import com.example.diaryboard.global.exception.CustomException;
@@ -12,8 +14,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import static com.example.diaryboard.global.exception.ExceptionCode.INVALID_POST;
-import static com.example.diaryboard.global.exception.ExceptionCode.INVALID_TOKEN;
+import static com.example.diaryboard.global.exception.ExceptionCode.*;
 
 @Service
 @RequiredArgsConstructor
@@ -39,5 +40,29 @@ public class CommentService {
         return Long.valueOf(SecurityContextHolder.getContext().getAuthentication().getName());
     }
 
+    public void deleteComment(Long commentId) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new CustomException(INVALID_COMMENT, "존재하지 않는 comment id입니다"));
 
+        Long memberId = getMemberIdFromAuthentication();
+        Member member = comment.getMember();
+
+        if (!member.getId().equals(memberId))
+            throw new CustomException(UNAUTHORIZED_COMMENT, "삭제 권한이 없습니다");
+
+        commentRepository.deleteById(commentId);
+    }
+
+    public void updateComment(Long commentId, UpdateCommentRequest dto) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new CustomException(INVALID_COMMENT, "존재하지 않는 comment id입니다"));
+
+        Long memberId = getMemberIdFromAuthentication();
+        Member member = comment.getMember();
+
+        if (!member.getId().equals(memberId))
+            throw new CustomException(UNAUTHORIZED_COMMENT, "수정 권한이 없습니다");
+
+        comment.updateContent(dto.getContent());
+    }
 }

--- a/src/main/java/com/example/diaryboard/service/CommentService.java
+++ b/src/main/java/com/example/diaryboard/service/CommentService.java
@@ -1,0 +1,13 @@
+package com.example.diaryboard.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CommentService {
+
+
+}

--- a/src/main/java/com/example/diaryboard/service/CommentService.java
+++ b/src/main/java/com/example/diaryboard/service/CommentService.java
@@ -25,12 +25,12 @@ public class CommentService {
     private final MemberRepository memberRepository;
     private final PostRepository postRepository;
 
-    public Long createComment(Long postId, CreateCommentRequest dto) {
+    public Long createComment(CreateCommentRequest dto) {
         Long memberId = getMemberIdFromAuthentication();
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new CustomException(INVALID_TOKEN, "존재하지 않는 subject입니다"));
 
-        Post post = postRepository.findById(postId)
+        Post post = postRepository.findById(dto.getPostId())
                 .orElseThrow(() -> new CustomException(INVALID_POST, "존재하지 않는 post id입니다"));
 
         return commentRepository.save(dto.toEntity(member, post)).getId();

--- a/src/main/java/com/example/diaryboard/service/CommentService.java
+++ b/src/main/java/com/example/diaryboard/service/CommentService.java
@@ -1,13 +1,43 @@
 package com.example.diaryboard.service;
 
+import com.example.diaryboard.dto.comment.CreateCommentRequest;
+import com.example.diaryboard.entity.Member;
+import com.example.diaryboard.entity.Post;
+import com.example.diaryboard.global.exception.CustomException;
+import com.example.diaryboard.repository.CommentRepository;
+import com.example.diaryboard.repository.MemberRepository;
+import com.example.diaryboard.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static com.example.diaryboard.global.exception.ExceptionCode.INVALID_POST;
+import static com.example.diaryboard.global.exception.ExceptionCode.INVALID_TOKEN;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final MemberRepository memberRepository;
+    private final PostRepository postRepository;
+
+    public Long createComment(Long postId, CreateCommentRequest dto) {
+        Long memberId = getMemberIdFromAuthentication();
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(INVALID_TOKEN, "존재하지 않는 subject입니다"));
+
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new CustomException(INVALID_POST, "존재하지 않는 post id입니다"));
+
+        return commentRepository.save(dto.toEntity(member, post)).getId();
+    }
+
+    private Long getMemberIdFromAuthentication() {
+        return Long.valueOf(SecurityContextHolder.getContext().getAuthentication().getName());
+    }
 
 
 }

--- a/src/main/java/com/example/diaryboard/service/PostService.java
+++ b/src/main/java/com/example/diaryboard/service/PostService.java
@@ -93,7 +93,8 @@ public class PostService {
 
         return switch (searchBy) {
             case ALL -> postRepository.findByKeyword(keyword, pageRequest).map(GetPostResponse::new);
-            case AUTHOR -> postRepository.findByMemberNicknameContaining(keyword, pageRequest).map(GetPostResponse::new);
+            case AUTHOR ->
+                    postRepository.findByMemberNicknameContaining(keyword, pageRequest).map(GetPostResponse::new);
             case TITLE -> postRepository.findByTitleContaining(keyword, pageRequest).map(GetPostResponse::new);
             case CONTENT -> postRepository.findByContentContaining(keyword, pageRequest).map(GetPostResponse::new);
         };

--- a/src/test/java/com/example/diaryboard/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/example/diaryboard/repository/CommentRepositoryTest.java
@@ -1,0 +1,90 @@
+package com.example.diaryboard.repository;
+
+import com.example.diaryboard.entity.Comment;
+import com.example.diaryboard.entity.Member;
+import com.example.diaryboard.entity.Post;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+class CommentRepositoryTest {
+
+    @Autowired
+    CommentRepository commentRepository;
+
+    @Autowired
+    PostRepository postRepository;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    Member saveMember;
+    Post savePost;
+
+    @BeforeEach
+    void beforeEach() {
+        Member member = Member.builder()
+                .nickname("임시완")
+                .email("test@gmail.com")
+                .password("test123!@#")
+                .build();
+
+        saveMember = memberRepository.save(member);
+
+        Post post = Post.builder()
+                .title("게시판 테스트")
+                .content("게시판테스트입니다.")
+                .member(saveMember)
+                .build();
+
+        savePost = postRepository.save(post);
+    }
+
+    @Test
+    void 댓글_생성_조회() {
+        // given
+        String content = "댓글 테스트";
+        Comment comment = Comment.builder()
+                .content(content)
+                .member(saveMember)
+                .post(savePost)
+                .build();
+
+        // when
+        Comment saveComment = commentRepository.save(comment);
+        Optional<Comment> findComment = commentRepository.findById(saveComment.getId());
+
+        // then
+        assertThat(findComment).isNotEmpty();
+        assertThat(findComment.get().getContent()).isEqualTo(content);
+        assertThat(findComment.get().getMember()).isEqualTo(saveMember);
+        assertThat(findComment.get().getPost()).isEqualTo(savePost);
+    }
+
+    @Test
+    void 댓글_생성_삭제() {
+        // given
+        String content = "댓글 테스트";
+        Comment comment = Comment.builder()
+                .content(content)
+                .member(saveMember)
+                .post(savePost)
+                .build();
+
+        // when
+        Comment saveComment = commentRepository.save(comment);
+        commentRepository.delete(saveComment);
+        Optional<Comment> findComment = commentRepository.findById(saveComment.getId());
+
+        // then
+        assertThat(findComment).isEmpty();
+    }
+}

--- a/src/test/java/com/example/diaryboard/service/CommentServiceTest.java
+++ b/src/test/java/com/example/diaryboard/service/CommentServiceTest.java
@@ -1,6 +1,7 @@
 package com.example.diaryboard.service;
 
 import com.example.diaryboard.dto.comment.CreateCommentRequest;
+import com.example.diaryboard.dto.comment.UpdateCommentRequest;
 import com.example.diaryboard.entity.Comment;
 import com.example.diaryboard.entity.Member;
 import com.example.diaryboard.entity.Post;
@@ -29,25 +30,18 @@ class CommentServiceTest {
 
     @Autowired
     CommentService commentService;
-
-    @Autowired
-    private CommentRepository commentRepository;
-
     @Autowired
     PostRepository postRepository;
-
     @Autowired
     MemberRepository memberRepository;
-
     @Autowired
     JwtProvider jwtProvider;
-
     @Autowired
     JwtDecoder jwtDecoder;
-
     CustomJwtAuthenticationConverter jwtAuthenticationConverter = new CustomJwtAuthenticationConverter();
-
     Long postId;
+    @Autowired
+    private CommentRepository commentRepository;
 
     @BeforeEach
     void beforeEach() {
@@ -88,5 +82,37 @@ class CommentServiceTest {
         assertThat(comment.get().getContent()).isEqualTo(request.getContent());
     }
 
+    @Test
+    void 댓글_삭제() {
+        // given
+        String content = "댓글 내용입니다.";
 
+        CreateCommentRequest request = new CreateCommentRequest(content);
+        Long commentId = commentService.createComment(postId, request);
+
+        // when
+        commentService.deleteComment(commentId);
+        Optional<Comment> comment = commentRepository.findById(commentId);
+
+        // then
+        assertThat(comment).isEmpty();
+    }
+
+    @Test
+    void 댓글_수정() {
+        // given
+        String content = "댓글 내용입니다.";
+
+        CreateCommentRequest request = new CreateCommentRequest(content);
+        Long commentId = commentService.createComment(postId, request);
+
+        String updatedContent = "수정된 댓글 내용입니다.";
+
+        // when
+        commentService.updateComment(commentId, new UpdateCommentRequest(updatedContent));
+        Comment comment = commentRepository.findById(commentId).orElseThrow();
+
+        // then
+        assertThat(comment.getContent()).isEqualTo(updatedContent);
+    }
 }

--- a/src/test/java/com/example/diaryboard/service/CommentServiceTest.java
+++ b/src/test/java/com/example/diaryboard/service/CommentServiceTest.java
@@ -30,18 +30,25 @@ class CommentServiceTest {
 
     @Autowired
     CommentService commentService;
+
     @Autowired
     PostRepository postRepository;
+
     @Autowired
     MemberRepository memberRepository;
+
     @Autowired
     JwtProvider jwtProvider;
+
     @Autowired
     JwtDecoder jwtDecoder;
+
     CustomJwtAuthenticationConverter jwtAuthenticationConverter = new CustomJwtAuthenticationConverter();
+
     Long postId;
+
     @Autowired
-    private CommentRepository commentRepository;
+    CommentRepository commentRepository;
 
     @BeforeEach
     void beforeEach() {
@@ -71,10 +78,10 @@ class CommentServiceTest {
     void 댓글_생성() {
         // given
         String content = "댓글 내용입니다.";
-        CreateCommentRequest request = new CreateCommentRequest(content);
+        CreateCommentRequest request = new CreateCommentRequest(postId, content);
 
         // when
-        Long commentId = commentService.createComment(postId, request);
+        Long commentId = commentService.createComment(request);
         Optional<Comment> comment = commentRepository.findById(commentId);
 
         // then
@@ -87,8 +94,8 @@ class CommentServiceTest {
         // given
         String content = "댓글 내용입니다.";
 
-        CreateCommentRequest request = new CreateCommentRequest(content);
-        Long commentId = commentService.createComment(postId, request);
+        CreateCommentRequest request = new CreateCommentRequest(postId, content);
+        Long commentId = commentService.createComment(request);
 
         // when
         commentService.deleteComment(commentId);
@@ -103,8 +110,8 @@ class CommentServiceTest {
         // given
         String content = "댓글 내용입니다.";
 
-        CreateCommentRequest request = new CreateCommentRequest(content);
-        Long commentId = commentService.createComment(postId, request);
+        CreateCommentRequest request = new CreateCommentRequest(postId, content);
+        Long commentId = commentService.createComment(request);
 
         String updatedContent = "수정된 댓글 내용입니다.";
 

--- a/src/test/java/com/example/diaryboard/service/CommentServiceTest.java
+++ b/src/test/java/com/example/diaryboard/service/CommentServiceTest.java
@@ -1,0 +1,92 @@
+package com.example.diaryboard.service;
+
+import com.example.diaryboard.dto.comment.CreateCommentRequest;
+import com.example.diaryboard.entity.Comment;
+import com.example.diaryboard.entity.Member;
+import com.example.diaryboard.entity.Post;
+import com.example.diaryboard.global.jwt.JwtProvider;
+import com.example.diaryboard.global.security.CustomJwtAuthenticationConverter;
+import com.example.diaryboard.repository.CommentRepository;
+import com.example.diaryboard.repository.MemberRepository;
+import com.example.diaryboard.repository.PostRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+class CommentServiceTest {
+
+    @Autowired
+    CommentService commentService;
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @Autowired
+    PostRepository postRepository;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    JwtProvider jwtProvider;
+
+    @Autowired
+    JwtDecoder jwtDecoder;
+
+    CustomJwtAuthenticationConverter jwtAuthenticationConverter = new CustomJwtAuthenticationConverter();
+
+    Long postId;
+
+    @BeforeEach
+    void beforeEach() {
+        Member member = Member.builder()
+                .nickname("임시완")
+                .email("test@gmail.com")
+                .password("test123!@#")
+                .build();
+
+        Long memberId = memberRepository.save(member).getId();
+        String subject = String.valueOf(memberId);
+        Jwt accessToken = jwtDecoder.decode(jwtProvider.generateAccessToken(subject));
+
+        Authentication authentication = jwtAuthenticationConverter.convert(accessToken);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        Post post = Post.builder()
+                .title("title")
+                .content("content")
+                .member(member)
+                .build();
+
+        postId = postRepository.save(post).getId();
+    }
+
+    @Test
+    void 댓글_생성() {
+        // given
+        String content = "댓글 내용입니다.";
+        CreateCommentRequest request = new CreateCommentRequest(content);
+
+        // when
+        Long commentId = commentService.createComment(postId, request);
+        Optional<Comment> comment = commentRepository.findById(commentId);
+
+        // then
+        assertThat(comment).isNotEmpty();
+        assertThat(comment.get().getContent()).isEqualTo(request.getContent());
+    }
+
+
+}


### PR DESCRIPTION
[BOARD-67](https://dev-cycle.atlassian.net/browse/BOARD-67)

- 댓글 생성, 수정, 삭제 API를 개발했습니다.

[BOARD-67]: https://dev-cycle.atlassian.net/browse/BOARD-67?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ